### PR TITLE
Update to `v0.2.4`

### DIFF
--- a/.claude/skills/bump-duckdb/SKILL.md
+++ b/.claude/skills/bump-duckdb/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: bump-duckdb
+description: Bump all DuckDB version references to adapt the extension to a new DuckDB release
+disable-model-invocation: true
+argument-hint: <new-duckdb-version e.g. v1.5.2>
+allowed-tools: Read, Edit, Bash(git *), Bash(cargo update *)
+---
+
+# Bump DuckDB Version
+
+Adapt this extension to a new DuckDB release version `$ARGUMENTS`.
+
+## Version Derivation
+
+Given a DuckDB version like `vX.Y.Z`:
+- **DuckDB version**: `vX.Y.Z` (used in CI workflow and Makefile)
+- **Rust crate version**: `1.{X * 10000 + Y * 100 + Z}.0` (e.g., `v1.5.1` → `1.10501.0`)
+- **Extension version**: read the current version from `Cargo.toml` `[package] version` and increment its patch number by 1
+
+## Files to Update
+
+### 1. `.github/workflows/MainDistributionPipeline.yml`
+Update all three version references:
+- The workflow `uses:` ref: `duckdb/extension-ci-tools/...@vX.Y.Z`
+- `duckdb_version: vX.Y.Z`
+- `ci_tools_version: vX.Y.Z`
+
+### 2. `Cargo.toml`
+- Bump `[package] version` (increment patch by 1)
+- Update `duckdb` dependency version to the new crate version
+- Update `duckdb-loadable-macros` dependency version to the new crate version
+- Update `libduckdb-sys` dependency version to the new crate version
+
+### 3. `Makefile`
+- Update `TARGET_DUCKDB_VERSION=vX.Y.Z`
+
+### 4. `extension-ci-tools` submodule
+Run: `git -C extension-ci-tools fetch --tags && git -C extension-ci-tools checkout vX.Y.Z`
+
+### 5. `Cargo.lock`
+Run: `cargo update duckdb duckdb-loadable-macros libduckdb-sys`
+
+## Procedure
+
+1. Parse the DuckDB version from `$ARGUMENTS` and derive the crate version and new extension version
+2. Read the current files to confirm current values
+3. Apply all edits
+4. Update the submodule
+5. Update Cargo.lock
+6. **Validate**: Re-read all updated files and verify that:
+   - `.github/workflows/MainDistributionPipeline.yml` contains the new DuckDB version in all three places and no references to the old version
+   - `Cargo.toml` has the new crate version for `duckdb`, `duckdb-loadable-macros`, and `libduckdb-sys`
+   - `Cargo.lock` has the new crate version for `duckdb`, `duckdb-loadable-macros`, and `libduckdb-sys`
+   - `Makefile` has the new `TARGET_DUCKDB_VERSION`
+   - `extension-ci-tools` submodule points to the new version tag (verify with `git -C extension-ci-tools describe --tags`)
+   - Report any mismatches as errors
+7. Show a summary of all changes made

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -15,10 +15,10 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.1
     with:
-      duckdb_version: v1.5.0
-      ci_tools_version: v1.5.0
+      duckdb_version: v1.5.1
+      ci_tools_version: v1.5.1
       extension_name: lsh
       extra_toolchains: rust;python3
       exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
+checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
 dependencies = [
  "bytes",
  "half",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -191,18 +191,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10500.0"
+version = "1.10501.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2048e4963a37ec458d9e93444192e0e949ac0a188d201ea53472f2c42db822"
+checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
 dependencies = [
  "arrow",
  "cast",
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb-loadable-macros"
-version = "1.10500.0"
+version = "1.10501.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a03f6c991339668c75f48ed41090289c1604f9a6b52c0dda328a6579765358f"
+checksum = "20a5fa8d567f3ee404518a9ac0bb15ce241161eeed3029a347da3f9c5a218ff9"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1060,9 +1060,9 @@ checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10500.0"
+version = "1.10501.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df9db064ff17120305ec6b7aee048f766cdf2a3ce9ffbb6953aaa3634605030"
+checksum = "12096c1694924782b3fe21e790630b77bacb4fcb7ad9d7ee0fec626f985bf248"
 dependencies = [
  "flate2",
  "pkg-config",
@@ -1129,7 +1129,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsh"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "duckdb",
  "duckdb-loadable-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsh"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 
 [lib]
@@ -20,9 +20,9 @@ path = "src/wasm_lib.rs"
 crate-type = ["staticlib"]
 
 [dependencies]
-duckdb = { version = "1.10500.0", features = ["vscalar", "vtab-arrow"] }
-duckdb-loadable-macros = "1.10500.0"
-libduckdb-sys = { version = "1.10500.0", features = ["loadable-extension"] }
+duckdb = { version = "1.10501.0", features = ["vscalar", "vtab-arrow"] }
+duckdb-loadable-macros = "1.10501.0"
+libduckdb-sys = { version = "1.10501.0", features = ["loadable-extension"] }
 ndarray = "0.16.1"
 ndarray-rand = "0.15.0"
 nohash-hasher = "0.2.0"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXTENSION_NAME=lsh
 USE_UNSTABLE_C_API=1
 
 # Target DuckDB version
-TARGET_DUCKDB_VERSION=v1.5.0
+TARGET_DUCKDB_VERSION=v1.5.1
 
 all: configure debug
 


### PR DESCRIPTION
Adapt to a new DuckDB release (`v1.5.1`).

Also, automate this process by adding `bump-duckdb` skill for Claude Code.