### PR TITLE
Update to `v0.2.5`

### DIFF
--- a/.claude/skills/bump-duckdb/SKILL.md
+++ b/.claude/skills/bump-duckdb/SKILL.md
@@ -1,57 +1,70 @@
 ---
 name: bump-duckdb
 description: Bump all DuckDB version references to adapt the extension to a new DuckDB release
-disable-model-invocation: true
 argument-hint: <new-duckdb-version e.g. v1.5.2>
-allowed-tools: Read, Edit, Bash(git *), Bash(cargo update *)
+allowed-tools: Read, Edit, Bash(git *), Bash(cargo *)
 ---
 
 # Bump DuckDB Version
 
-Adapt this extension to a new DuckDB release version `$ARGUMENTS`.
+Adapt this extension to DuckDB version `$ARGUMENTS` (denoted `vX.Y.Z` below).
 
-## Version Derivation
+## Derived versions
 
-Given a DuckDB version like `vX.Y.Z`:
-- **DuckDB version**: `vX.Y.Z` (used in CI workflow and Makefile)
-- **Rust crate version**: `1.{X * 10000 + Y * 100 + Z}.0` (e.g., `v1.5.1` → `1.10501.0`)
-- **Extension version**: read the current version from `Cargo.toml` `[package] version` and increment its patch number by 1
+- **Crate version**: `1.{X*10000 + Y*100 + Z}.0` (e.g. `v1.5.1` → `1.10501.0`)
+- **New extension version**: read `[package] version` in `Cargo.toml` and increment patch by 1
 
-## Files to Update
+## Steps
 
-### 1. `.github/workflows/MainDistributionPipeline.yml`
-Update all three version references:
-- The workflow `uses:` ref: `duckdb/extension-ci-tools/...@vX.Y.Z`
-- `duckdb_version: vX.Y.Z`
-- `ci_tools_version: vX.Y.Z`
+### 1. Probe availability
 
-### 2. `Cargo.toml`
-- Bump `[package] version` (increment patch by 1)
-- Update `duckdb` dependency version to the new crate version
-- Update `duckdb-loadable-macros` dependency version to the new crate version
-- Update `libduckdb-sys` dependency version to the new crate version
+Run both checks, then branch on results:
 
-### 3. `Makefile`
-- Update `TARGET_DUCKDB_VERSION=vX.Y.Z`
+```bash
+cargo search duckdb | grep '^duckdb = "1\.{X*10000+Y*100+Z}\.0"'
+git -C extension-ci-tools fetch --tags
+git -C extension-ci-tools tag -l vX.Y.Z
+```
 
-### 4. `extension-ci-tools` submodule
-Run: `git -C extension-ci-tools fetch --tags && git -C extension-ci-tools checkout vX.Y.Z`
+- **Crate not published** → **abort**. Report: "Crate `1.{...}.0` not on crates.io yet; wait for the release." Do not modify any files.
+- **`extension-ci-tools` tag missing** → continue, but mark CI-tooling updates as _skipped_ (see step 2).
 
-### 5. `Cargo.lock`
-Run: `cargo update duckdb duckdb-loadable-macros libduckdb-sys`
+### 2. Apply edits
 
-## Procedure
+| File                                             | Change                                                                  | Skip if `extension-ci-tools` tag missing? |
+| ------------------------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------- |
+| `.github/workflows/MainDistributionPipeline.yml` | `duckdb_version: vX.Y.Z`                                                | no                                        |
+| `.github/workflows/MainDistributionPipeline.yml` | `uses: duckdb/extension-ci-tools/...@vX.Y.Z`                            | yes                                       |
+| `.github/workflows/MainDistributionPipeline.yml` | `ci_tools_version: vX.Y.Z`                                              | yes                                       |
+| `Cargo.toml`                                     | `[package] version` → new extension version                             | no                                        |
+| `Cargo.toml`                                     | `duckdb`, `duckdb-loadable-macros`, `libduckdb-sys` → new crate version | no                                        |
+| `Makefile`                                       | `TARGET_DUCKDB_VERSION=vX.Y.Z`                                          | no                                        |
 
-1. Parse the DuckDB version from `$ARGUMENTS` and derive the crate version and new extension version
-2. Read the current files to confirm current values
-3. Apply all edits
-4. Update the submodule
-5. Update Cargo.lock
-6. **Validate**: Re-read all updated files and verify that:
-   - `.github/workflows/MainDistributionPipeline.yml` contains the new DuckDB version in all three places and no references to the old version
-   - `Cargo.toml` has the new crate version for `duckdb`, `duckdb-loadable-macros`, and `libduckdb-sys`
-   - `Cargo.lock` has the new crate version for `duckdb`, `duckdb-loadable-macros`, and `libduckdb-sys`
-   - `Makefile` has the new `TARGET_DUCKDB_VERSION`
-   - `extension-ci-tools` submodule points to the new version tag (verify with `git -C extension-ci-tools describe --tags`)
-   - Report any mismatches as errors
-7. Show a summary of all changes made
+Then run:
+
+```bash
+cargo update duckdb duckdb-loadable-macros libduckdb-sys   # always
+git -C extension-ci-tools checkout vX.Y.Z                  # skip if tag missing
+```
+
+### 3. Validate
+
+Re-read every file modified in step 2 and confirm the new values are present. Verify the submodule tag (only if checked out):
+
+```bash
+git -C extension-ci-tools describe --tags
+```
+
+Report any mismatch as an error.
+
+### 4. Summarize
+
+Report:
+
+- What was updated
+- What was skipped, with reason
+- If anything was skipped: remind the user to re-run this skill once the missing release is available
+
+## Why some updates can be skipped
+
+The CI tooling (`extension-ci-tools` submodule + workflow `uses:` ref + `ci_tools_version`) just downloads the DuckDB binary specified by `duckdb_version`, so older tooling works fine with a newer DuckDB. Everything else is compiled into the extension binary and must match exactly to avoid ABI mismatches.

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.1
     with:
-      duckdb_version: v1.5.1
+      duckdb_version: v1.5.2
       ci_tools_version: v1.5.1
       extension_name: lsh
       extra_toolchains: rust;python3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,8 @@ version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
 dependencies = [
+ "crossterm 0.27.0",
+ "crossterm 0.28.1",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width",
@@ -414,6 +416,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "parking_lot",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -481,12 +516,13 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
+checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
 dependencies = [
  "arrow",
  "cast",
+ "comfy-table",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -499,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb-loadable-macros"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a5fa8d567f3ee404518a9ac0bb15ce241161eeed3029a347da3f9c5a218ff9"
+checksum = "0c15036a8d19f31f53acef09ff910c96cff5fe9b5d8f59e6dc90e7b836e09b20"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1060,9 +1096,9 @@ checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12096c1694924782b3fe21e790630b77bacb4fcb7ad9d7ee0fec626f985bf248"
+checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
 dependencies = [
  "flate2",
  "pkg-config",
@@ -1105,6 +1141,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -1114,6 +1156,15 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1129,7 +1180,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsh"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "duckdb",
  "duckdb-loadable-macros",
@@ -1289,6 +1340,29 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1706,6 +1780,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -1713,7 +1800,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1763,6 +1850,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seahash"
@@ -2353,6 +2446,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,7 +2719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsh"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 
 [lib]
@@ -20,9 +20,9 @@ path = "src/wasm_lib.rs"
 crate-type = ["staticlib"]
 
 [dependencies]
-duckdb = { version = "1.10501.0", features = ["vscalar", "vtab-arrow"] }
-duckdb-loadable-macros = "1.10501.0"
-libduckdb-sys = { version = "1.10501.0", features = ["loadable-extension"] }
+duckdb = { version = "1.10502.0", features = ["vscalar", "vtab-arrow"] }
+duckdb-loadable-macros = "1.10502.0"
+libduckdb-sys = { version = "1.10502.0", features = ["loadable-extension"] }
 ndarray = "0.16.1"
 ndarray-rand = "0.15.0"
 nohash-hasher = "0.2.0"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXTENSION_NAME=lsh
 USE_UNSTABLE_C_API=1
 
 # Target DuckDB version
-TARGET_DUCKDB_VERSION=v1.5.1
+TARGET_DUCKDB_VERSION=v1.5.2
 
 all: configure debug
 


### PR DESCRIPTION
Adapt to a new DuckDB release (`v1.5.2`).

Also, update `bump-duckdb` skill to handle unavailable downstream releases:
- Rust crates (`libduckdb-sys`, `duckdb`, `duckdb-loadable-macros`): aborts if not on crates.io — FFI bindings must match exactly to avoid link errors or ABI crashes.
- `extension-ci-tools` (submodule + workflow refs): skipped with a warning if the tag is missing — it only downloads the DuckDB binary, so older tooling works fine.